### PR TITLE
Move Metric Name to Root Object

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -84,8 +84,12 @@ func (promSrv *PrometheusServer) handlePrometheus(w http.ResponseWriter, r *http
 		event := map[string]interface{}{}
 		labels := map[string]interface{}{}
 		for _, l := range ts.Labels {
-			fieldName := strings.Replace(l.Name, "_", "", -1)
-			labels[fieldName] = l.Value
+			if fieldName == "__name__" {
+				event["name"] = l.Value	
+			} else {
+				fieldName := strings.Replace(l.Name, "_", "", -1)
+				labels[fieldName] = l.Value
+			}
 		}
 		event["labels"] = labels
 


### PR DESCRIPTION
If a metric has a label of `name`, the metric name can be overridden when label keys are stripped of `_`.