### PR TITLE
Fix name field collision

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -7,6 +7,3 @@ prometheusbeat:
   listen: ":8080"
   # Context path. Defaults to /prometheus
   context: "/prometheus"
-
-  # If this setting is set to true the metric name field is stored as a top-level field. Defaults to false
-  # name_under_root: false

--- a/config/config.go
+++ b/config/config.go
@@ -21,13 +21,11 @@
 package config
 
 type Config struct {
-	Listen        string `config:"listen"`
-	Context       string `config:"context"`
-	NameUnderRoot bool   `config:"name_under_root"`
+	Listen  string `config:"listen"`
+	Context string `config:"context"`
 }
 
 var DefaultConfig = Config{
-	Listen:        ":8080",
-	Context:       "/prometheus",
-	NameUnderRoot: false,
+	Listen:  ":8080",
+	Context: "/prometheus",
 }

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,0 +1,27 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveCharacters(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{input: "__under_score__", output: "under_score__"},
+		{input: "c,omma", output: "comma"},
+		{input: "test#it#", output: "testit"},
+		{input: "white space", output: "whitespace"},
+		{input: "normal_name", output: "normal_name"},
+	}
+
+	specialChars := "#, "
+
+	for _, test := range tests {
+		o := removeSpecialCharacters(test.input, specialChars)
+		assert.Equal(t, test.output, o)
+	}
+}

--- a/prometheusbeat.yml
+++ b/prometheusbeat.yml
@@ -8,9 +8,6 @@ prometheusbeat:
   # Context path. Defaults to /prometheus
   context: "/prometheus"
 
-  # If this setting is set to true the metric name field is stored as a top-level field. Defaults to false
-  # name_under_root: false
-
 #================================ General =====================================
 
 # The name of the shipper that publishes the network data. It can be used to group


### PR DESCRIPTION
Fixes #24 when the timeseries has a label with name `"name"`.

**Breaking change**: The `"__name__"` field of the Prometheus timeseries always gets moved to the root level of the json document and renamed to `"name"`.
